### PR TITLE
ARGV compromise and less output for big archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Analyze facebook copy of your data. Download zip file from facebook and get info
 
 ** Enjoy! **
 
+# Contributing
 
+Please consider running your changes with `ruby benchmark.rb [PATH_TO_YOUR_FACEBOOK_ARCHIVE]` before making a pull request. Changes that significantly slow this project may be rejected
 
 # Sorry for code quality, it was proof of concept. It will be refactored in the future.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,22 @@ Analyze facebook copy of your data. Download zip file from facebook and get info
 9. Run `ruby analyze_facebook_data.rb path_to_catalog_with_copy_of_facebook_data` in my case this command looked like: `ruby analyze_facebook_data.rb /Users/przemyslawmroczek/Downloads/facebook-przemekmroczek90/`
 10. You will see the script running and analyzing your conversations. At the end you will see it generated new excel file `facebook_analysis.xlsx`
 
+Optional:
+If the `DEBUG` environment variable is present, the script will print the name of every message as it is analyzed instead of the total count.
+```bash
+ruby analyze_facebook_data.rb example/facebook-monaleigh
+Analyzing 5 messages...
+Finished 5 messages...
+```
+```bash
+DEBUG=true ruby analyze_facebook_data.rb example/facebook-monaleigh
+Analyzing conversation with: Abbie Carter
+Analyzing conversation with: Allison Walker
+Analyzing conversation with: Cindi Gray
+Analyzing conversation with: Kate Hunter
+Analyzing conversation with: Suzanne Nash
+```
+
 # What's inside
 
 * Ranking of friends by messages (number of messages sent, who sent more, how many words, characters in conversation)

--- a/benchmark.rb
+++ b/benchmark.rb
@@ -1,13 +1,12 @@
-# To set up the test, replace in facebook_data_analyzer/analyze_facebook_data.rb the following line:
-# Workbook.new(catalog: ARGV[0])
-# with:
-# Workbook.new(catalog: '/Users/.../facebook_data_analyzer/example/facebook-monaleigh/')
-# A complete path needs to be specified instead of /.../ .
+# To run the benchmark, call:
+# ruby benchmark.rb [PATH_TO_FACEBOOK_DIRECTORY]
 
-# Run the test in Terminal with the following command:
-# ruby benchmark.rb
+# If PATH_TO_FACEBOOK_DIRECTORY is omitted, the minimal archive at `./example/facebook-monaleigh` will be used instead
 
 require 'benchmark'
+
+WORKBOOK = File.join(File.dirname(__FILE__), 'example/facebook-monaleigh')
+ARGV[0] = ARGV[0] || WORKBOOK
 
 Benchmark.bm do |x|
   x.report { require_relative 'analyze_facebook_data' }

--- a/lib/analyze_facebook_data.rb
+++ b/lib/analyze_facebook_data.rb
@@ -14,6 +14,10 @@ class AnalyzeFacebookData
 
   # AnalyzeMessages
   def start
+    unless ENV['DEBUG']
+      puts "Analyzing #{messages_files.count} messages..."
+    end
+
     messages_files.each do |file|
       # open current file
       content = File.open(file)
@@ -33,8 +37,9 @@ class AnalyzeFacebookData
         total_count: 0
       }
 
-      # Debug
-      puts "Analyzing conversation with: #{friend_name}"
+      if ENV['DEBUG']
+        puts "Analyzing conversation with: #{friend_name}"
+      end
 
       # whole conversation
       conversation = doc.css('.thread').children
@@ -94,6 +99,10 @@ class AnalyzeFacebookData
           friends[friend_name][:friend_words]       += paragraph_words.length
         end
       end
+    end
+
+    unless ENV['DEBUG']
+      puts "Finished #{messages_files.count} messages..."
     end
     self
   end


### PR DESCRIPTION
Thanks so much for your work here! 

e938d49 should address @thnukid['s comment](https://github.com/Lackoftactics/facebook_data_analyzer/pull/12#pullrequestreview-114991018) - CLI arguments are optional when using `benchmark.rb`
```bash
ruby benchmark.rb
       user     system      total        real
Analyzing 5 messages...
Finished 5 messages...
  0.330000   1.110000   1.440000 (  1.775601)
```

```bash
ruby benchmark.rb ../../Documents/Facebook
       user     system      total        real
Analyzing 964 messages...
Finished 964 messages...
 17.680000   1.890000  19.570000 ( 30.174141)
```

b263d9a should help out a lot with @northcott-j['s parallelizing](https://github.com/Lackoftactics/facebook_data_analyzer/pull/13) by suppressing names unless `DEBUG=true` is set
```bash
DEBUG=true ruby benchmark.rb
       user     system      total        real
Analyzing conversation with: Abbie Carter
Analyzing conversation with: Allison Walker
Analyzing conversation with: Cindi Gray
Analyzing conversation with: Kate Hunter
Analyzing conversation with: Suzanne Nash
  0.430000   1.030000   1.460000 (  1.590534)
```
